### PR TITLE
Disable cursor movement on arrow up

### DIFF
--- a/src/Input.svelte
+++ b/src/Input.svelte
@@ -59,6 +59,8 @@
     function handleKeyDown(event) {
         if ($open) return;
         if (event.code === 'ArrowUp') {
+            // this prevents the cursor from moving to the start of input
+            event.preventDefault();
             if (historyIndex > 0) {
                 historyIndex -= 1;
             }


### PR DESCRIPTION
Html text input default behavior on up arrow is to move the cursor to the start of the input. We just want to prevent this.

Closes #40 